### PR TITLE
优化批量写入数据时IO操作 提升写入速度 300%+

### DIFF
--- a/snapsdb.go
+++ b/snapsdb.go
@@ -57,6 +57,10 @@ func (db *defaultDB) StorageDirectory() string {
 	return db.basePath
 }
 
+func (db *defaultDB) QueryTimelineUnix(timeline int64, lp_out_slice interface{}) error {
+	return db.QueryTimeline(time.Unix(timeline, 0), lp_out_slice)
+}
+
 func (db *defaultDB) QueryTimeline(timeline time.Time, out_list interface{}) error {
 	// 获取时间戳的时间基线，当天的0点时间戳，文件名
 	timebaseline := util.GetUnixOfDay(timeline)
@@ -69,9 +73,13 @@ func (db *defaultDB) QueryTimeline(timeline time.Time, out_list interface{}) err
 		if err != nil {
 			return err
 		}
-		return storeFile.QueryTimeline(timeline, slice_pointer, origin_slice, element_type)
+		return storeFile.QueryTimeline(timeline.Unix(), slice_pointer, origin_slice, element_type)
 	}
 	return nil
+}
+
+func (db *defaultDB) QueryBetweenUnix(begin int64, end int64, lp_out_map interface{}) error {
+	return db.QueryBetween(time.Unix(begin, 0), time.Unix(end, 0), lp_out_map)
 }
 
 func (db *defaultDB) QueryBetween(begin time.Time, end time.Time, out_map interface{}) error {
@@ -97,7 +105,7 @@ func (db *defaultDB) QueryBetween(begin time.Time, end time.Time, out_map interf
 		if err != nil && err != ErrorDBFileNotHit {
 			return err
 		} else if err == nil {
-			err = storeFile.QueryBetween(begin, end, map_object, key_type, slice_type, element_type)
+			err = storeFile.QueryBetween(begin.Unix(), end.Unix(), map_object, key_type, slice_type, element_type)
 			if err != nil {
 				return err
 			}
@@ -108,6 +116,10 @@ func (db *defaultDB) QueryBetween(begin time.Time, end time.Time, out_map interf
 	return nil
 }
 
+func (db *defaultDB) WriteUnix(timeline int64, data ...StoreData) error {
+	return db.Write(time.Unix(timeline, 0), data...)
+}
+
 func (db *defaultDB) Write(timeline time.Time, data ...StoreData) error {
 	// 获取时间戳的时间基线，当天的0点时间戳，文件名
 	timebaseline := util.GetUnixOfDay(timeline)
@@ -115,7 +127,7 @@ func (db *defaultDB) Write(timeline time.Time, data ...StoreData) error {
 	if err != nil {
 		return err
 	}
-	return storeFile.Write(timeline, data...)
+	return storeFile.Write(timeline.Unix(), data...)
 }
 
 func (db *defaultDB) loadFile(timebaseline int64, autoCreated bool) (StoreFile, error) {
@@ -144,6 +156,10 @@ func (db *defaultDB) freeFile(timebaseline int64) {
 		db.opendFiles[timebaseline].Close()
 		delete(db.opendFiles, timebaseline)
 	}
+}
+
+func (db *defaultDB) DeleteStorageFileUnix(timeline int64) error {
+	return db.DeleteStorageFile(time.Unix(timeline, 0))
 }
 
 func (db *defaultDB) DeleteStorageFile(timeline time.Time) error {

--- a/test/db_test.go
+++ b/test/db_test.go
@@ -67,7 +67,7 @@ func TestSnapshotDBWriteOnce(t *testing.T) {
 	v3 := &types.ProcessInfo{Pid: 3, Name: "docker-compose - 3", Cpu: 30.03, Mem: 93.45, Virt: 30000000000, Res: 330000000000000}
 	v4 := &types.ProcessInfo{Pid: 4, Name: "docker-compose - 4", Cpu: 40.04, Mem: 94.56, Virt: 40000000000, Res: 440000000000000}
 	v5 := &types.ProcessInfo{Pid: 5, Name: "docker-compose - 5", Cpu: 50.05, Mem: 95.67, Virt: 50000000000, Res: 550000000000000}
-	timestamp := time.Date(2022, 01, 01, 01, 01, 01, 01, time.Local)
+	timestamp := time.Date(2022, 9, 22, 13, 27, 43, 0, time.Local)
 	fmt.Println(timestamp.Format("2006-01-02 15:04:05"))
 	start := time.Now() // 获取当前时间
 	db.Write(timestamp, v1, v2, v3, v4, v5)
@@ -80,7 +80,7 @@ func TestSnapshotDBQuery(t *testing.T) {
 	db := InitDB()
 	timestamp := time.Date(2022, 9, 22, 13, 27, 43, 0, time.Local)
 	list := make([]types.ProcessInfo, 0)
-	list = append(list, types.ProcessInfo{Pid: 5, Name: "docker-compose - 1111", Cpu: 50.05, Mem: 95.67, Virt: 50000000000, Res: 550000000000000})
+	// list = append(list, types.ProcessInfo{Pid: 5, Name: "docker-compose - 1111", Cpu: 50.05, Mem: 95.67, Virt: 50000000000, Res: 550000000000000})
 	start := time.Now()
 	err := db.QueryTimeline(timestamp, &list)
 	cost := time.Since(start)

--- a/typed.go
+++ b/typed.go
@@ -54,11 +54,16 @@ const (
 	NextDataOffset = int64(8)
 	// 文件第一条数据的偏移位置
 	FileDataOffset = uint32(MateTableSize + FileHeaderOffset)
+	// timeline    8 byte
+	// nextdata    4 byte
+	// datalen     4 byte
+	DataHeaderLen = 8 + 4 + 4
 )
 
 type SnapsDB interface {
 	// write one or more pieces of data to the timeline.
 	Write(timeline time.Time, data ...StoreData) error
+	WriteUnix(timeline int64, data ...StoreData) error
 	// Query a certain timeline data, and return to the slice
 	// the slice type should be inherited from protoreflect.ProtoMessage
 	/*
@@ -68,6 +73,7 @@ type SnapsDB interface {
 		db.QueryTimeline(timestamp, &list)
 	*/
 	QueryTimeline(timeline time.Time, lp_out_slice interface{}) error
+	QueryTimelineUnix(timeline int64, lp_out_slice interface{}) error
 	// query the data of a certain time interval and return the data to lp_out_map,
 	// typed protobuf.proto
 	// ErrorDBFileNotHit
@@ -86,9 +92,11 @@ type SnapsDB interface {
 		db.QueryBetween(beginTimestamp, endTimestamp, &map)
 	*/
 	QueryBetween(begin time.Time, end time.Time, lp_out_map interface{}) error
+	QueryBetweenUnix(begin int64, end int64, lp_out_map interface{}) error
 
 	/* Delete the stored file for the current day of the timeline */
 	DeleteStorageFile(timeline time.Time) error
+	DeleteStorageFileUnix(timeline int64) error
 
 	/* Get data file storage directory */
 	StorageDirectory() string
@@ -102,11 +110,11 @@ type SnapsDB interface {
 
 type StoreFile interface {
 	// 写入数据
-	Write(timestamp time.Time, data ...StoreData) error
+	Write(timestamp int64, data ...StoreData) error
 	// query a timeline for data and return to a list
-	QueryTimeline(timestamp time.Time, slice_pointer *reflect.Value, origin_slice *reflect.Value, element_type *reflect.Type) error
+	QueryTimeline(timestamp int64, slice_pointer *reflect.Value, origin_slice *reflect.Value, element_type *reflect.Type) error
 	// Query the data of a certain time interval and fill it with map[][]typed
-	QueryBetween(begin time.Time, end time.Time, map_object reflect.Value, key_type *reflect.Kind, slice_type *reflect.Type, element_type *reflect.Type) error
+	QueryBetween(begin int64, end int64, map_object reflect.Value, key_type *reflect.Kind, slice_type *reflect.Type, element_type *reflect.Type) error
 	// close file
 	Close()
 	// read file timeline meta information


### PR DESCRIPTION
优化批量写入时和并数据写入 降低文件读写的IO操作
测试批量写入提升写入速度 300%+

增加文件读写API
WriteUnix(timeline int64, data ...StoreData) error
QueryTimelineUnix(timeline int64, lp_out_slice interface{}) error
QueryBetweenUnix(begin int64, end int64, lp_out_map interface{}) error
DeleteStorageFileUnix(timeline int64) error
